### PR TITLE
Fix missing API base URL default

### DIFF
--- a/app/build/page.tsx
+++ b/app/build/page.tsx
@@ -49,7 +49,8 @@ interface ProjectsData {
 }
 
 const BuildPage: React.FC = () => {
-    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    // Default to an empty string if the environment variable is undefined
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
     const [currentStep, setCurrentStep] = useState(1);
     const [isLoading, setIsLoading] = useState(false);

--- a/app/task/page.tsx
+++ b/app/task/page.tsx
@@ -18,7 +18,8 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
 }));
 
 const TaskPageContent  = () => {
-    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    // Default to an empty string if the environment variable is undefined
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '';
     const router = useRouter();
 
     const searchParams = useSearchParams();

--- a/app/vm/page.tsx
+++ b/app/vm/page.tsx
@@ -18,7 +18,8 @@ interface Vm {
 const VmsDashboard: React.FC = () => {
     const [vms, setVms] = useState<Vm[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
-    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    // Default to an empty string if the environment variable is undefined
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '';
     const [notification, setNotification] = useState({ show: false, message: '' });
 
     const didFetch = useRef(false);


### PR DESCRIPTION
## Summary
- handle missing NEXT_PUBLIC_API_BASE_URL in build, VM, and task pages

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68464de83e28832fa2a50868ca75607e