### PR TITLE
Add Node test for formatTime

### DIFF
--- a/__tests__/formatTime.test.ts
+++ b/__tests__/formatTime.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatTime } from '../app/history/page';
+
+test('formatTime returns 00:00:00 for non-positive values', () => {
+  assert.equal(formatTime(0), '00:00:00');
+  assert.equal(formatTime(-1000), '00:00:00');
+});
+
+test('formatTime formats milliseconds into hh:mm:ss', () => {
+  assert.equal(formatTime(5000), '00:00:05');
+  assert.equal(formatTime(61000), '00:01:01');
+  assert.equal(formatTime(3661000), '01:01:01');
+});

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -8,7 +8,7 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import './history.css';
 
-function formatTime(ms: number): string {
+export function formatTime(ms: number): string {
     if (ms <= 0) {
         return '00:00:00';
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next export",
+    "test": "node --loader ts-node/esm --test __tests__/formatTime.test.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.13.5",
@@ -36,6 +37,7 @@
     "eslint-config-next": "14.2.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
## Summary
- export `formatTime` helper from history page
- add Node test for `formatTime`
- add `test` script using Node's built-in test runner
- add `ts-node` dev dependency for running TypeScript tests

## Testing
- `npm test` *(fails: Cannot find package 'ts-node' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684652445490832fabeb82ff105236a7